### PR TITLE
refactor: update commitizen version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 ## Setup
 
-Install commitizen version 2.8.2
+Install commitizen
 
 ```
-npm install -g commitizen@2.8.2
+npm install -g commitizen
 ```
 
 Install the `mol-conventional-changelog` package.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "word-wrap": "^1.1.0"
   },
   "devDependencies": {
-    "commitizen": ">=2.8.0 <2.8.3",
+    "commitizen": "^2.9.6",
     "eslint": "^3.8.1",
     "eslint-config-mailonline": "^2.0.0",
     "husky": "^0.11.9",


### PR DESCRIPTION
There is not restriction on the version of commitizen to use anymore